### PR TITLE
Revert "point to the right bit (#53)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ let nibbles = 0b1010_0001_1000_0101;
 
 // Is bit 7 on? It sure is!
 // 0b1010_0001_1000_0101
-//           ^
+//             ^
 //
 // We can double check: 
 console.log(!!(nibbles & (1 << 7))); // true


### PR DESCRIPTION
This reverts commit 2c87220569edb9188c2232aec20379878ea49be8.

Fixes #55.

People number the bits incrementally, going from the Least Significant
Bit (LSB), the rightmost one, to the Most Significant Bit, all the way
to the left.

It functions in accordance with their weight. For instance:
- the bit 0 is weighted 2^0
- the bit 7 is weighted 2^7